### PR TITLE
Added instructions for using asdf install

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+erlang 24.1.2
+elixir 1.12.3-otp-24
+nodejs 17.5.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # FlyingPenguin
 
+Make sure you have [asdf](https://asdf-vm.com/guide/getting-started.html#_1-install-dependencies) installed
+
+Install all of the relevant versions of elixir, erlang and nodejs with asdf
+  * `asdf install`
+
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`


### PR DESCRIPTION
asdf install is now used in order to set the version of erlang, elixir,
and nodejs.